### PR TITLE
Create Dockerfile for build environment

### DIFF
--- a/docker/conman-buildenv-bionic/Dockerfile
+++ b/docker/conman-buildenv-bionic/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+
+RUN apt update && \
+  DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt install --yes \
+  build-essential \
+  gfortran

--- a/docker/conman-buildenv-bionic/README.md
+++ b/docker/conman-buildenv-bionic/README.md
@@ -1,0 +1,1 @@
+Build environment for ConMan using the Ubuntu Bionic (18.04) Docker container.


### PR DESCRIPTION
We use DockerHub's automatic container builds to allow the project repository to contain the Dockerfile, allowing for devs to be able to make changes that are reflected in the [geodynamics DockerHub](https://hub.docker.com/u/geodynamics) containers. Using containers for build environments allows for dependencies to be made explicit in an easily readable way.

See Calypso, Rayleigh, BurnMan, and VirtualQuake for examples of how this works.