### PR TITLE
Add missing steps scope

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
       steps {
         sh '''
           cd src
-          make
+          make -f Makefile-gfort64
         '''
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,10 +14,12 @@ pipeline {
 
   stages {
     stage('Build') {
-      sh '''
-        cd src
-        make
-      '''
+      steps {
+        sh '''
+          cd src
+          make
+        '''
+      }
     }
   }
 }


### PR DESCRIPTION
The sh command needs to be in a `steps` scope.