### PR TITLE
add docker.yml to test continuous integration of Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,14 @@
+name: Docker Image CI
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker image build -< ./docker/conman/Dockerfile --tag conman-ci:$(date +%s)


### PR DESCRIPTION
A few weeks ago we talked about setting up github workflows for continuous integration. I set up docker.yml to build a docker image from docker/conman/Dockerfile to make sure that new commits don't break the docker image. If this looks good and is what you had in mind, I can start setting these up for the other repositories which I've containerized. Thanks! @ljhwang @gassmoeller 